### PR TITLE
cannot build on linux with clang without include

### DIFF
--- a/Source/PicoGKGLTexture.cpp
+++ b/Source/PicoGKGLTexture.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <fstream>
 #include <vector>
+#include <cstring>
 
 #pragma pack(1)
 


### PR DESCRIPTION
Without this include, there are build errors when compiling on Linux with Clang and gcc:
```
Building CXX object CMakeFiles/picogk.1.0.dir/Source/PicoGKGLTexture.cpp.o
/root/picogk/PicoGKRuntime/Source/PicoGKGLTexture.cpp:140:9: error: use of undeclared identifier 'strncmp'
    if (strncmp(achMagic, "DDS ", 4) != 0)
        ^
/root/picogk/PicoGKRuntime/Source/PicoGKGLTexture.cpp:226:18: error: no member named 'memcpy' in namespace 'std'
            std::memcpy(oBuffer.data(), pBuffer + nBufferOffset, nMipSize);
            ~~~~~^
2 errors generated.
make[2]: *** [CMakeFiles/picogk.1.0.dir/build.make:76: CMakeFiles/picogk.1.0.dir/Source/PicoGKGLTexture.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:294: CMakeFiles/picogk.1.0.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```