### PR TITLE
fix(build): enable position independent  code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,15 @@ project(PicoGK VERSION ${LIB_VERSION})
 # Set the C++ standard to C++20 or higher
 set(CMAKE_CXX_STANDARD 20)
 
+# Check for position independent executable support
+include(CheckPIESupported)
+check_pie_supported(OUTPUT_VARIABLE output LANGUAGES C CXX)
+if( NOT CMAKE_C_LINK_PIE_SUPPORTED or NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+  message(WARNING "PIE is not supported at link time: ${output}.\n"
+                  "PIE link options will not be passed to linker.")
+endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
 # Set the output directory for the generated libraries and executables
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Dist)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Lib)


### PR DESCRIPTION
I attempted to match the existing cmake style.
CMake doc reference: https://cmake.org/cmake/help/latest/module/CheckPIESupported.html#checkpiesupported

Fixes #14
