### PR TITLE
fix fragment shader compiling error

### DIFF
--- a/Source/PicoGKGLViewerShaders.cpp
+++ b/Source/PicoGKGLViewerShaders.cpp
@@ -237,7 +237,7 @@ void main()
         }
     }
     
-    float fVdotN   = clamp(dot(-vec3View, vec3N), 0, 1.0);
+    float fVdotN   = clamp(dot(-vec3View, vec3N), .0f, 1.0);
     float fFresnel = fMetallic + (1.0 - fMetallic) * pow(1.0 - fVdotN, 5.0) * (1.0 - fRoughness * 0.9);
     
     vec3 vec3Diff  = textureLod(texDiff, vec3N, 0).xyz * vec3Color;
@@ -313,7 +313,7 @@ void main()
 
     // Lighting logic from standard shader
 
-    float fVdotN   = clamp(dot(-vec3View, vec3N), 0, 1.0);
+    float fVdotN   = clamp(dot(-vec3View, vec3N), .0f, 1.0);
     float fFresnel = fMetallic + (1.0 - fMetallic) * pow(1.0 - fVdotN, 5.0) * (1.0 - fRoughness * 0.9);
 
     vec3 vec3Diff  = textureLod(texDiff, vec3N, 0).xyz * vec3Color;


### PR DESCRIPTION
Built under Debian Linux 12

```
terminate called after throwing an instance of 'PicoGK::GlShaderProgram::ShaderProgramException'
  what():  Shader program error: Error compiling Fragment shader 0(51) : error C1101: ambiguous overloaded function reference "clamp(float, int, float)"
    (0) : gp5 float64_t clamp(float64_t, float64_t, float64_t)
    (0) : float clamp(float, float, float)
```