### PR TITLE
HandleManager::bIsValid: use shared_lock not unique_lock

### DIFF
--- a/Source/PicoGKHandleManager.h
+++ b/Source/PicoGKHandleManager.h
@@ -93,7 +93,7 @@ public:
     /// Check if a handle is valid (exists)
     inline bool bIsValid(Handle h) const 
     {
-        std::unique_lock lk(m_mtx);
+        std::shared_lock lk(m_mtx);
         return m_map.count(h) != 0;
     }
 


### PR DESCRIPTION
bIsValid is const but uses unique_lock; the other const methods
(roGet, nAllocatedCount, nMemUsage) use shared_lock. Introduced in 068bc62

Throughput of 4 reader threads with N extra threads hitting
bIsValid in a loop (median of 5 × 2-second samples):

| Extra threads | unique_lock | shared_lock |
|---------------|-------------|-------------|
| 0             | 18.3 M/s    | 19.0 M/s    |
| 4             | 10.7 M/s    | 16.5 M/s    |
| 8             | 2.4 M/s     | 7–9.5 M/s   |

8-thread C# workload: 25.6s → 22.2s.