### PR TITLE
Fix narrow-band unit confusion in IntersectImplicit and ProjectZSlice (#26)

### DIFF
--- a/Source/PicoGKVdbVoxels.h
+++ b/Source/PicoGKVdbVoxels.h
@@ -387,7 +387,7 @@ public:
     {
         PKTRACE(Voxels_IntersectImplicit);
         
-        Voxels oVox(oVoxelSize(), fBackgroundMM());
+        Voxels oVox(oVoxelSize(), m_nSdfNarrowBand);
         
         CoordBBox oBBox = m_roGrid->evalActiveVoxelBoundingBox();
         
@@ -479,7 +479,7 @@ public:
         }
         
         // Close the last slice, and update the background
-        for(int32_t z = iZEnd; z > iZEnd - (int) (0.5f + m_roGrid->background()); z--)
+        for(int32_t z = iZEnd; z > iZEnd - m_nSdfNarrowBand; z--)
         {
             for(int32_t x = oBBox.min().x(); x <= oBBox.max().x(); x++)
             for(int32_t y = oBBox.min().y(); y <= oBBox.max().y(); y++)
@@ -520,7 +520,7 @@ public:
         }
         
         // Close the last slice, and update the background
-        for(int32_t z = iZEnd; z < iZEnd + (int) (0.5f + m_roGrid->background()); z++)
+        for(int32_t z = iZEnd; z < iZEnd + m_nSdfNarrowBand; z++)
         {
             for(int32_t x = oBBox.min().x(); x <= oBBox.max().x(); x++)
             for(int32_t y = oBBox.min().y(); y <= oBBox.max().y(); y++)


### PR DESCRIPTION
Fixes the two confirmed instances of #26 — a background value in **mm** used as an integer **voxel/narrow-band count**, which truncates at fine voxel sizes.

## Changes (`Source/PicoGKVdbVoxels.h`, 3 lines)
- **`IntersectImplicit`** — build the temp grid with `m_nSdfNarrowBand` instead of `fBackgroundMM()`. The `Voxels(VoxelSize, int nNarrowBand)` ctor's 2nd arg is a voxel count, but `fBackgroundMM()` returns millimetres (`narrowBand × voxelSize`). Below ~0.33 mm this truncated to `int 0` → a grid with background 0 → `csgIntersection` threw `expected grid A outside value > 0, got 0`, so every implicit intersect at a fine voxel size failed.
- **`ProjectZSliceDn` / `ProjectZSliceUp`** — seal the end cap by iterating `m_nSdfNarrowBand` slices instead of `(int)(0.5f + background())`. Below ~0.167 mm that was 0 → the cap was never sealed → a **non-watertight** result, produced silently (no error).

No behavioural change near 1 mm voxel size (where `3 × voxelSize ≈ 1`); correct at all voxel sizes now.

## Verification
Verified through [PicoPie](https://github.com/Borderliner/PicoPie) (which currently applies these exact edits as a build-time patch). At `voxel_size = 0.1 mm`:
- `ProjectZSlice` of a solid into empty space: **was ~22 mm³ (non-watertight) → 828.9 mm³**, matching the 0.5 mm baseline (818 mm³, modulo discretisation).
- `IntersectImplicit` (e.g. sphere ∩ gyroid): no longer throws; produces the expected non-empty volume.
- Full downstream test suite green, including a voxel-size sweep (0.1–1.0 mm).

Leaves the two lower-severity candidates from #26 (imported-grid hardcoded narrow band; `vecToMM` fractional truncation) for separate discussion.

---
*Reported & fixed via [PicoPie](https://github.com/Borderliner/PicoPie), a Pythonic binding of PicoGK.*
