### PR TITLE
Harden the C ABI: catch C++ exceptions instead of terminating the process (#27)

### DIFF
--- a/Source/PicoGKLibrary.cpp
+++ b/Source/PicoGKLibrary.cpp
@@ -55,138 +55,241 @@ void SafeCopyInfoString(const std::string s, char psz[PKINFOSTRINGLEN])
     psz[PKINFOSTRINGLEN-1] = 0;
 }
 
+
+// ---- PICOGK_NEVER_ABORT_GUARD (injected by PicoPie scripts/patch_runtime.py) --------------
+#include <string>
+#include <cstring>
+#include <cmath>
+#include <exception>
+static std::string g_pkLastError;
+extern "C" {
+#if defined(_WIN32)
+__declspec(dllexport) int g_pkLastErrorFlag = 0;
+#else
+__attribute__((visibility("default"))) int g_pkLastErrorFlag = 0;
+#endif
+}
+PICOGK_API void PicoGK_SetError(const char* psz) {
+    g_pkLastError = (psz != nullptr) ? psz : "PicoGK: unknown native error";
+    g_pkLastErrorFlag = 1;
+}
+PICOGK_API int PicoGK_nGetLastError(char* psz, int nMax) {
+    int n = (int) g_pkLastError.size();
+    if (psz != nullptr && nMax > 0) {
+        int c = (n < nMax - 1) ? n : nMax - 1;
+        std::memcpy(psz, g_pkLastError.data(), (size_t) c);
+        psz[c] = 0;
+    }
+    return n;
+}
+#define PICOGK_GUARD_TRY g_pkLastErrorFlag = 0; try {
+#define PICOGK_GUARD_CATCH(s) } \
+    catch (const std::exception& e) { PicoGK_SetError(e.what()); return s; } \
+    catch (...) { PicoGK_SetError("PicoGK: unknown native error"); return s; }
+#define PICOGK_GUARD_CATCH_VOID } \
+    catch (const std::exception& e) { PicoGK_SetError(e.what()); return; } \
+    catch (...) { PicoGK_SetError("PicoGK: unknown native error"); return; }
+// ---------------------------------------------------------------------------
+
 PICOGK_API void Library_GetName(char psz[PKINFOSTRINGLEN])
 {
+    PICOGK_GUARD_TRY
    SafeCopyInfoString(Library::oLib().strName(), psz);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Library_GetVersion(char psz[PKINFOSTRINGLEN])
 {
+    PICOGK_GUARD_TRY
     SafeCopyInfoString(Library::oLib().strVersion(), psz);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Library_GetBuildInfo(char psz[PKINFOSTRINGLEN])
 {
+    PICOGK_GUARD_TRY
     SafeCopyInfoString(Library::oLib().strBuildInfo(), psz);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKINSTANCE Library_hCreateInstance(float fVoxelSizeMM)
 {
+    PICOGK_GUARD_TRY
     return Library::oLib().nCreateInstance(fVoxelSizeMM);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Library_DestroyInstance(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_DestroyInstance);
     Library::oLib().DestroyInstance(hThis);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int64_t Library_nTotalMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nTotalMemUsage);
     return Library::oLib().roGetInstance(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nMeshesMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nMeshesMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oMeshes.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nLatticesMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nLatticesMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oLattices.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nPolyLinesMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nPolyLinesMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oPolyLines.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVoxelsMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVoxelsMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oVoxels.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVdbFilesMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVdbFilesMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oVdbFiles.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nScalarFieldsMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nScalarFieldsMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oScalarFields.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVectorFieldsMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVectorFieldsMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oVectorFields.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVdbMetasMemUsage(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVdbMetasMemUsage);
     return Library::oLib().roGetInstance(hThis)->m_oVdbMetas.nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nMeshesAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nMeshesAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oMeshes.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nLatticesAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nLatticesAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oLattices.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nPolyLinesAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nPolyLinesAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oPolyLines.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVoxelsAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVoxelsAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oVoxels.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVdbFilesAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVdbFilesAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oVdbFiles.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nScalarFieldsAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nScalarFieldsAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oScalarFields.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVectorFieldsAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVectorFieldsAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oVectorFields.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t Library_nVdbMetasAllocated(PKINSTANCE hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_nVdbMetasAllocated);
     return Library::oLib().roGetInstance(hThis)->m_oVdbMetas.nAllocatedCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Library_VoxelsToMm( PKINSTANCE hLib,
                                     const PKVector3* pvecVoxelCoordinate,
                                     PKVector3* pvecMmCoordinate)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_VoxelsToMm);
     
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
@@ -195,12 +298,15 @@ PICOGK_API void Library_VoxelsToMm( PKINSTANCE hLib,
     pvecMmCoordinate->X = oVoxelSize.fToMM(pvecVoxelCoordinate->X);
     pvecMmCoordinate->Y = oVoxelSize.fToMM(pvecVoxelCoordinate->Y);
     pvecMmCoordinate->Z = oVoxelSize.fToMM(pvecVoxelCoordinate->Z);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Library_MmToVoxels( PKINSTANCE hLib,
                                     const PKVector3* pvecMmCoordinate,
                                     PKVector3* pvecVoxelCoordinate)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Library_MmToVoxels);
     
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
@@ -209,39 +315,51 @@ PICOGK_API void Library_MmToVoxels( PKINSTANCE hLib,
     pvecVoxelCoordinate->X = oVoxelSize.iToVoxels(pvecMmCoordinate->X);
     pvecVoxelCoordinate->Y = oVoxelSize.iToVoxels(pvecMmCoordinate->Y);
     pvecVoxelCoordinate->Z = oVoxelSize.iToVoxels(pvecMmCoordinate->Z);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKMESH Mesh_hCreate(PKINSTANCE hLib)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Mesh_hCreate);
     
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.hAdd(std::make_shared<Mesh>());
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKMESH Mesh_hCreateFromVoxels(   PKINSTANCE hLib,
                                             PKVOXELS hVoxels)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Mesh_hCreateFromVoxels);
     
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr roVoxels = roLib->m_oVoxels.roGet(hVoxels);
     return roLib->m_oMeshes.hAdd(roVoxels->roAsMesh());
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool Mesh_bIsValid(  PKINSTANCE hLib,
                                 PKMESH hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Mesh_bIsValid);
     
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Mesh_Destroy(   PKINSTANCE hLib,
                                 PKMESH hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -249,23 +367,31 @@ PICOGK_API void Mesh_Destroy(   PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oMeshes.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int64_t Mesh_nMemUsage(  PKINSTANCE hLib,
                                     PKMESH hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Mesh_nMemUsage);
     
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t Mesh_nAddVertex( PKINSTANCE hLib,
                                     PKMESH hThis,
                                     const Vector3* pvecVertex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.roGet(hThis)->nAddVertex(*pvecVertex);
+
+    PICOGK_GUARD_CATCH(0)
 }
     
 PICOGK_API void Mesh_GetVertex( PKINSTANCE hLib,
@@ -273,23 +399,32 @@ PICOGK_API void Mesh_GetVertex( PKINSTANCE hLib,
                                 int32_t     nVertex,
                                 PKVector3*    pvecVertex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oMeshes.roGet(hThis)->GetVertex(nVertex, pvecVertex);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int32_t Mesh_nVertexCount(   PKINSTANCE hLib,
                                         PKMESH hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.roGet(hThis)->nVertexCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t Mesh_nAddTriangle(   PKINSTANCE hLib,
                                         PKMESH hThis,
                                         const PKTriangle* psTri)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.roGet(hThis)->nAddTriangle(*psTri);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Mesh_GetTriangle(   PKINSTANCE hLib,
@@ -297,8 +432,11 @@ PICOGK_API void Mesh_GetTriangle(   PKINSTANCE hLib,
                                     int32_t nTriangle,
                                     PKTriangle* psTri)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.roGet(hThis)->GetTriangle( nTriangle, psTri);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Mesh_GetTriangleV(  PKINSTANCE hLib,
@@ -308,46 +446,62 @@ PICOGK_API void Mesh_GetTriangleV(  PKINSTANCE hLib,
                                     PKVector3*  pvecB,
                                     PKVector3*  pvecC)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oMeshes.roGet(hThis)->GetTriangle(
                                 nTriangle,
                                 pvecA,
                                 pvecB,
                                 pvecC);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Mesh_GetBoundingBox(    PKINSTANCE hLib,
                                         PKMESH hThis,
                                         PKBBox3* poBox)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     *poBox = roLib->m_oMeshes.roGet(hThis)->oBBox();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int32_t Mesh_nTriangleCount( PKINSTANCE hLib,
                                         PKMESH hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oMeshes.roGet(hThis)->nTriangleCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKLATTICE Lattice_hCreate(PKINSTANCE hLib)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Lattice_hCreate);
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oLattices.hAdd(std::make_shared<Lattice>());
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool Lattice_bIsValid(   PKINSTANCE hLib,
                                     PKLATTICE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oLattices.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Lattice_Destroy(    PKINSTANCE hLib,
                                     PKLATTICE hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -355,15 +509,20 @@ PICOGK_API void Lattice_Destroy(    PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oLattices.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int64_t Lattice_nMemUsage(   PKINSTANCE hLib,
                                         PKLATTICE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Lattice::Ptr* proThis = (Lattice::Ptr*) hThis;
     return roLib->m_oLattices.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Lattice_AddSphere(  PKINSTANCE hLib,
@@ -371,10 +530,13 @@ PICOGK_API void Lattice_AddSphere(  PKINSTANCE hLib,
                                     const PKVector3* vecCenter,
                                     float fRadius)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oLattices.roGet(hThis)
         ->AddSphere(     *vecCenter,
                          fRadius);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Lattice_AddBeam(    PKINSTANCE hLib,
@@ -385,6 +547,7 @@ PICOGK_API void Lattice_AddBeam(    PKINSTANCE hLib,
                                     float fRadiusB,
                                     bool  bRoundCap)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oLattices.roGet(hThis)
         ->AddBeam(  *pvecA,
@@ -392,31 +555,42 @@ PICOGK_API void Lattice_AddBeam(    PKINSTANCE hLib,
                     fRadiusA,
                     fRadiusB,
                     bRoundCap);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKVOXELS Voxels_hCreate(PKINSTANCE hLib)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.hAdd(   std::make_shared<Voxels>(   roLib->fVoxelSizeMM(),
                                                                 PICOGK_VOXEL_DEFAULTNARROWBAND));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVOXELS Voxels_hCreateCopy( PKINSTANCE hLib,
                                         PKVOXELS hSource)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.hAdd(std::make_shared<Voxels>(*roLib->m_oVoxels.roGet(hSource)));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVOXELS Voxels_hCreateSphere(   PKINSTANCE          hLib,
                                             const PKVector3*    pvecCenter,
                                             float               fRadius)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.hAdd(std::make_shared<Voxels>(  roLib->fVoxelSizeMM(),
                                                             PICOGK_VOXEL_DEFAULTNARROWBAND,
                                                             *pvecCenter,
                                                             fRadius));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVOXELS Voxels_hCreateCapsule(  PKINSTANCE          hLib,
@@ -425,6 +599,7 @@ PICOGK_API PKVOXELS Voxels_hCreateCapsule(  PKINSTANCE          hLib,
                                             float               fRadius1,
                                             float               fRadius2)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.hAdd(std::make_shared<Voxels>(  roLib->fVoxelSizeMM(),
                                                             PICOGK_VOXEL_DEFAULTNARROWBAND,
@@ -432,36 +607,48 @@ PICOGK_API PKVOXELS Voxels_hCreateCapsule(  PKINSTANCE          hLib,
                                                             *pvecStop,
                                                             fRadius1,
                                                             fRadius2));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVOXELS Voxels_hCreateMeshShell(    PKINSTANCE          hLib,
                                                 PKMESH              hMesh,
                                                 float               fRadius)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.hAdd(std::make_shared<Voxels>(  roLib->fVoxelSizeMM(),
                                                             PICOGK_VOXEL_DEFAULTNARROWBAND,
                                                             *roLib->m_oMeshes.roGet(hMesh),
                                                             fRadius));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool Voxels_bIsValid(    PKINSTANCE hLib,
                                     PKVOXELS hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API bool Voxels_bIsEmpty(    PKINSTANCE hLib,
                                     PKVOXELS hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)->bIsEmpty();
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Voxels_Destroy( PKINSTANCE hLib,
                                 PKVOXELS hThis)
 {
+    PICOGK_GUARD_TRY
     
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
@@ -470,62 +657,85 @@ PICOGK_API void Voxels_Destroy( PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oVoxels.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool Voxels_bDiagnose(   PKINSTANCE  hLib,
                                     PKVOXELS    hThis,
                                     char    psz[PKINFOSTRINGLEN])
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     std::string strDiagnostic = roLib->m_oVoxels.roGet(hThis)->strDiagnose();
     SafeCopyInfoString(strDiagnostic, psz);
     return strDiagnostic.length() == 0;
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API int64_t Voxels_nMemUsage(    PKINSTANCE hLib,
                                         PKVOXELS hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API float Voxels_fVoxelSize( PKINSTANCE  hLib,
                                     PKVOXELS    hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return (float) roLib->m_oVoxels.roGet(hThis)->oVoxelSize();
+
+    PICOGK_GUARD_CATCH(NAN)
 }
 
 PICOGK_API void Voxels_BoolAdd( PKINSTANCE hLib,
                                 PKVOXELS hThis,
                                 PKVOXELS hOther)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)->BoolAdd(*roLib->m_oVoxels.roGet(hOther));
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_BoolSubtract(    PKINSTANCE hLib,
                                         PKVOXELS hThis,
                                         PKVOXELS hOther)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)->BoolSubtract(*roLib->m_oVoxels.roGet(hOther));
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_BoolIntersect(   PKINSTANCE hLib,
                                         PKVOXELS hThis,
                                         PKVOXELS hOther)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)->BoolIntersect(*roLib->m_oVoxels.roGet(hOther));
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_Offset(  PKINSTANCE hLib,
                                 PKVOXELS hThis,
                                 float fDist)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)->Offset(fDist);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_DoubleOffset(    PKINSTANCE hLib,
@@ -533,16 +743,22 @@ PICOGK_API void Voxels_DoubleOffset(    PKINSTANCE hLib,
                                         float fDist1,
                                         float fDist2)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)->DoubleOffset(fDist1, fDist2);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_TripleOffset(    PKINSTANCE hLib,
                                         PKVOXELS hThis,
                                         float fDist)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)->TripleOffset(fDist);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 
@@ -550,9 +766,12 @@ PICOGK_API void Voxels_RenderMesh(  PKINSTANCE hLib,
                                     PKVOXELS hThis,
                                     PKMESH hMesh)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)
         ->RenderMesh(*roLib->m_oMeshes.roGet(hMesh));
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_RenderImplicit(  PKINSTANCE hLib,
@@ -560,28 +779,37 @@ PICOGK_API void Voxels_RenderImplicit(  PKINSTANCE hLib,
                                         const PKBBox3* poBBox,
                                         PKPFnfSdf pfnSDF)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)
         ->RenderImplicit(   *poBBox,
                             pfnSDF);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_IntersectImplicit(   PKINSTANCE hLib,
                                             PKVOXELS hThis,
                                             PKPFnfSdf pfnSDF)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)
         ->IntersectImplicit(    pfnSDF);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_RenderLattice(   PKINSTANCE hLib,
                                         PKVOXELS hThis,
                                         PKLATTICE hLattice)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)
         ->RenderLattice(    *roLib->m_oLattices.roGet(hLattice));
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_ProjectZSlice(   PKINSTANCE hLib,
@@ -589,34 +817,46 @@ PICOGK_API void Voxels_ProjectZSlice(   PKINSTANCE hLib,
                                         float fZStart,
                                         float fZEnd)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)
         ->ProjectZSlice(    fZStart,
                             fZEnd);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool Voxels_bIsEqual(    PKINSTANCE hLib,
                                     PKVOXELS hThis,
                                     PKVOXELS hOther)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)
         ->bIsEqual(*roLib->m_oVoxels.roGet(hOther));
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API float Voxels_fCalculateVolume(   PKINSTANCE hLib,
                                             PKVOXELS hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)->fCalculateVolume();
+
+    PICOGK_GUARD_CATCH(NAN)
 }
 
 PICOGK_API bool Voxels_bIsInside(   PKINSTANCE hLib,
                                     PKVOXELS hThis,
                                     const PKVector3* pvecTestPoint)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)->bIsInside(*pvecTestPoint);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Voxels_GetSurfaceNormal(    PKINSTANCE hLib,
@@ -624,10 +864,13 @@ PICOGK_API void Voxels_GetSurfaceNormal(    PKINSTANCE hLib,
                                             const PKVector3*    pvecSurfacePoint,
                                             PKVector3*          pvecNormal)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVoxels.roGet(hThis)
         ->GetSurfaceNormal( *pvecSurfacePoint,
                             pvecNormal);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool Voxels_bClosestPointOnSurface(  PKINSTANCE hLib,
@@ -635,10 +878,13 @@ PICOGK_API bool Voxels_bClosestPointOnSurface(  PKINSTANCE hLib,
                                                 const PKVector3*    pvecSearch,
                                                 PKVector3*          pvecSurfacePoint)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)
         ->bFindClosestPointOnSurface(  *pvecSearch,
                                         pvecSurfacePoint);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API bool Voxels_bRayCastToSurface(   PKINSTANCE hLib,
@@ -647,11 +893,14 @@ PICOGK_API bool Voxels_bRayCastToSurface(   PKINSTANCE hLib,
                                             const PKVector3*    pvecDirection,
                                             PKVector3*          pvecSurfacePoint)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)
         ->bRayCastToSurface(    *pvecSearch,
                                 *pvecDirection,
                                 pvecSurfacePoint);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Voxels_GetVoxelDimensions(  PKINSTANCE hLib,
@@ -663,6 +912,7 @@ PICOGK_API void Voxels_GetVoxelDimensions(  PKINSTANCE hLib,
                                             int32_t* pnYSize,
                                             int32_t* pnZSize)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVoxels.roGet(hThis)
         ->GetVoxelDimensions(   pnXOrigin,
@@ -671,6 +921,8 @@ PICOGK_API void Voxels_GetVoxelDimensions(  PKINSTANCE hLib,
                                 pnXSize,
                                 pnYSize,
                                 pnZSize);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_GetXSlice(   PKINSTANCE hLib,
@@ -679,11 +931,14 @@ PICOGK_API void Voxels_GetXSlice(   PKINSTANCE hLib,
                                     float*      pfBuffer,
                                     float*      pfBackgroundValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr roThis = roLib->m_oVoxels.roGet(hThis);
     *pfBackgroundValue = roThis->fBackgroundMM();
     return roThis->GetXSlice(nXSlice, pfBuffer);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_GetYSlice(   PKINSTANCE hLib,
@@ -692,11 +947,14 @@ PICOGK_API void Voxels_GetYSlice(   PKINSTANCE hLib,
                                     float*      pfBuffer,
                                     float*      pfBackgroundValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr roThis = roLib->m_oVoxels.roGet(hThis);
     *pfBackgroundValue = roThis->fBackgroundMM();
     return roThis->GetYSlice(nYSlice, pfBuffer);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_GetZSlice(   PKINSTANCE hLib,
@@ -705,11 +963,14 @@ PICOGK_API void Voxels_GetZSlice(   PKINSTANCE hLib,
                                     float*      pfBuffer,
                                     float*      pfBackgroundValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr roThis = roLib->m_oVoxels.roGet(hThis);
     *pfBackgroundValue = roThis->fBackgroundMM();
     return roThis->GetZSlice(nZSlice, pfBuffer);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Voxels_GetInterpolatedZSlice(   PKINSTANCE hLib,
@@ -718,30 +979,40 @@ PICOGK_API void Voxels_GetInterpolatedZSlice(   PKINSTANCE hLib,
                                                 float*      pfBuffer,
                                                 float*      pfBackgroundValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr roThis = roLib->m_oVoxels.roGet(hThis);
     *pfBackgroundValue = roThis->fBackgroundMM();
     return roThis->GetInterpolatedZSlice(fZSlice, pfBuffer);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKPOLYLINE PolyLine_hCreate( PKINSTANCE hLib,
                                         const PKColorFloat*  pclr)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oPolyLines.hAdd(std::make_shared<PolyLine>(*pclr));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool PolyLine_bIsValid(  PKINSTANCE hLib,
                                     PKPOLYLINE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oPolyLines.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void PolyLine_Destroy(   PKINSTANCE hLib,
                                     PKPOLYLINE hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -749,21 +1020,29 @@ PICOGK_API void PolyLine_Destroy(   PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oPolyLines.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int64_t PolyLine_nMemUsage(  PKINSTANCE hLib,
                                         PKPOLYLINE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oPolyLines.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t PolyLine_nAddVertex( PKINSTANCE hLib,
                                         PKPOLYLINE hThis,
                                         const Vector3* pvec)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oPolyLines.roGet(hThis)->nAddVertex(*pvec);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void PolyLine_GetVertex( PKINSTANCE hLib,
@@ -771,31 +1050,43 @@ PICOGK_API void PolyLine_GetVertex( PKINSTANCE hLib,
                                     int32_t nIndex,
                                     PKVector3* pvec)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oPolyLines.roGet(hThis)->GetVertex(nIndex, pvec);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void PolyLine_GetBoundingBox(    PKINSTANCE hLib,
                                             PKPOLYLINE hThis,
                                             PKBBox3* poBox)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     *poBox = roLib->m_oPolyLines.roGet(hThis)->oBBox();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int32_t PolyLine_nVertexCount(   PKINSTANCE hLib,
                                             PKPOLYLINE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oPolyLines.roGet(hThis)->nVertexCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void PolyLine_GetColor(  PKINSTANCE hLib,
                                     PKPOLYLINE hThis,
                                     PKColorFloat* pclr)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     *pclr = roLib->m_oPolyLines.roGet(hThis)->clrLines();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 
@@ -803,13 +1094,17 @@ PICOGK_API void PolyLine_GetColor(  PKINSTANCE hLib,
 
 PICOGK_API PKVDBFILE VdbFile_hCreate(PKINSTANCE hLib)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.hAdd(std::make_shared<VdbFile>());
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVDBFILE VdbFile_hCreateFromFile(   PKINSTANCE hLib,
                                                 const char* pszFileName)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     VdbFile::Ptr roVdbFile = VdbFile::roFromFile(pszFileName);
@@ -818,18 +1113,24 @@ PICOGK_API PKVDBFILE VdbFile_hCreateFromFile(   PKINSTANCE hLib,
         return 0;
     
     return roLib->m_oVdbFiles.hAdd(roVdbFile);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool VdbFile_bIsValid(   PKINSTANCE hLib,
                                     PKVDBFILE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void VdbFile_Destroy(    PKINSTANCE hLib,
                                     PKVDBFILE hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -837,27 +1138,36 @@ PICOGK_API void VdbFile_Destroy(    PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oVdbFiles.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int64_t VdbFile_nMemUsage(   PKINSTANCE hLib,
                                         PKVDBFILE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool VdbFile_bSaveToFile(    PKINSTANCE hLib,
                                         PKVDBFILE       hThis,
                                         const char*     pszFileName)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.roGet(hThis)->bSaveToFile(pszFileName);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API PKVOXELS VdbFile_hGetVoxels( PKINSTANCE hLib,
                                         PKVDBFILE   hThis,
                                         int32_t     nIndex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     auto roVdbFile = roLib->m_oVdbFiles.roGet(hThis);
     
@@ -871,6 +1181,8 @@ PICOGK_API PKVOXELS VdbFile_hGetVoxels( PKINSTANCE hLib,
             
     return roLib->m_oVoxels.hAdd(std::make_shared<Voxels>(  gridPtrCast<FloatGrid>(roGrid),
                                                             PICOGK_VOXEL_DEFAULTNARROWBAND));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t VdbFile_nAddVoxels(  PKINSTANCE hLib,
@@ -878,16 +1190,20 @@ PICOGK_API int32_t VdbFile_nAddVoxels(  PKINSTANCE hLib,
                                         const char* pszFieldName,
                                         PKVOXELS    hVoxels)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.roGet(hThis)
         ->nAddGrid(pszFieldName, roLib->m_oVoxels.roGet(hVoxels)->roVdbGrid());
     
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKSCALARFIELD VdbFile_hGetScalarField(   PKINSTANCE hLib,
                                                     PKVDBFILE hThis,
                                                     int32_t nIndex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     auto roVdbFile = roLib->m_oVdbFiles.roGet(hThis);
     
@@ -900,6 +1216,8 @@ PICOGK_API PKSCALARFIELD VdbFile_hGetScalarField(   PKINSTANCE hLib,
     // PicoGK stores scalar fields as fog volumes
     
     return roLib->m_oScalarFields.hAdd(std::make_shared<ScalarField>(gridPtrCast<FloatGrid>(roGrid)));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t VdbFile_nAddScalarField( PKINSTANCE hLib,
@@ -907,15 +1225,19 @@ PICOGK_API int32_t VdbFile_nAddScalarField( PKINSTANCE hLib,
                                             const char*     pszFieldName,
                                             PKSCALARFIELD   hScalarField)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.roGet(hThis)
         ->nAddGrid(pszFieldName, roLib->m_oScalarFields.roGet(hScalarField)->roVdbGrid());
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVECTORFIELD VdbFile_hGetVectorField(   PKINSTANCE hLib,
                                                     PKVDBFILE   hThis,
                                                     int32_t     nIndex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     auto roVdbFile = roLib->m_oVdbFiles.roGet(hThis);
     
@@ -925,6 +1247,8 @@ PICOGK_API PKVECTORFIELD VdbFile_hGetVectorField(   PKINSTANCE hLib,
         return 0;
         
     return roLib->m_oVectorFields.hAdd(std::make_shared<VectorField>(gridPtrCast<Vec3SGrid>(roGrid)));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t VdbFile_nAddVectorField( PKINSTANCE hLib,
@@ -932,17 +1256,23 @@ PICOGK_API int32_t VdbFile_nAddVectorField( PKINSTANCE hLib,
                                             const char*     pszFieldName,
                                             PKVECTORFIELD   hVectorField)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     return roLib->m_oVdbFiles.roGet(hThis)
         ->nAddGrid(pszFieldName, roLib->m_oVectorFields.roGet(hVectorField)->roVdbGrid());
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t VdbFile_nFieldCount( PKINSTANCE hLib,
                                         PKVDBFILE hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.roGet(hThis)->nGridCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void VdbFile_GetFieldName(   PKINSTANCE hLib,
@@ -950,45 +1280,61 @@ PICOGK_API void VdbFile_GetFieldName(   PKINSTANCE hLib,
                                         int32_t     nIndex,
                                         char        psz[PKINFOSTRINGLEN])
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     SafeCopyInfoString( roLib->m_oVdbFiles.roGet(hThis)->strNameAt(nIndex),
                         psz);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int VdbFile_nFieldType(  PKINSTANCE hLib,
                                     PKVDBFILE   hThis,
                                     int32_t     nIndex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbFiles.roGet(hThis)->nTypeAt(nIndex);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKSCALARFIELD ScalarField_hCreate(PKINSTANCE hLib)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oScalarFields.hAdd(std::make_shared<ScalarField>(roLib->fVoxelSizeMM()));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKSCALARFIELD ScalarField_hCreateCopy(   PKINSTANCE hLib,
                                                     PKSCALARFIELD hSource)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     ScalarField::Ptr roSource = roLib->m_oScalarFields.roGet(hSource);
     ScalarField::Ptr roNew = std::make_shared<ScalarField>(*roSource);
     return roLib->m_oScalarFields.hAdd(roNew);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool ScalarField_bIsValid(   PKINSTANCE hLib,
                                         PKSCALARFIELD hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oScalarFields.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void ScalarField_Destroy(    PKINSTANCE hLib,
                                         PKSCALARFIELD   hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -996,23 +1342,31 @@ PICOGK_API void ScalarField_Destroy(    PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oScalarFields.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int64_t ScalarField_nMemUsage(   PKINSTANCE hLib,
                                             PKSCALARFIELD hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oScalarFields.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKSCALARFIELD ScalarField_hCreateFromVoxels( PKINSTANCE hLib,
                                                         PKVOXELS hVoxels)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr         roSource = roLib->m_oVoxels.roGet(hVoxels);
     ScalarField::Ptr    roNew = std::make_shared<ScalarField>(*roSource);
     return roLib->m_oScalarFields.hAdd(roNew);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKSCALARFIELD ScalarField_hBuildFromVoxels(  PKINSTANCE hLib,
@@ -1020,6 +1374,7 @@ PICOGK_API PKSCALARFIELD ScalarField_hBuildFromVoxels(  PKINSTANCE hLib,
                                                         float       fScalarValue,
                                                         float       fSdThreshold)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr         roSource = roLib->m_oVoxels.roGet(hVoxels);
@@ -1027,6 +1382,8 @@ PICOGK_API PKSCALARFIELD ScalarField_hBuildFromVoxels(  PKINSTANCE hLib,
     
     roNew->BuildFieldFrom(roSource, fScalarValue, fSdThreshold);
     return roLib->m_oScalarFields.hAdd(roNew);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void ScalarField_SetValue(   PKINSTANCE hLib,
@@ -1034,11 +1391,14 @@ PICOGK_API void ScalarField_SetValue(   PKINSTANCE hLib,
                                         const PKVector3*    pvecPosition,
                                         float               fValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     roLib->m_oScalarFields.roGet(hThis)
         ->SetValue(     *pvecPosition,
                         fValue);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool ScalarField_bGetValue(  PKINSTANCE hLib,
@@ -1046,18 +1406,24 @@ PICOGK_API bool ScalarField_bGetValue(  PKINSTANCE hLib,
                                         const PKVector3*    pvecPosition,
                                         float*              pfValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oScalarFields.roGet(hThis)
         ->bGetValue(    *pvecPosition,
                         pfValue);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void ScalarField_RemoveValue(    PKINSTANCE          hLib,
                                             PKSCALARFIELD       hThis,
                                             const PKVector3*    pvecPosition)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oScalarFields.roGet(hThis)->RemoveValue(   *pvecPosition);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void ScalarField_GetVoxelDimensions( PKINSTANCE hLib,
@@ -1069,6 +1435,7 @@ PICOGK_API void ScalarField_GetVoxelDimensions( PKINSTANCE hLib,
                                                 int32_t* pnYSize,
                                                 int32_t* pnZSize)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oScalarFields.roGet(hThis)
         ->GetVoxelDimensions(   pnXOrigin,
@@ -1077,51 +1444,69 @@ PICOGK_API void ScalarField_GetVoxelDimensions( PKINSTANCE hLib,
                                 pnXSize,
                                 pnYSize,
                                 pnZSize);
-    }
+    
+    PICOGK_GUARD_CATCH_VOID
+}
 
 PICOGK_API void ScalarField_GetSlice(   PKINSTANCE hLib,
                                         PKSCALARFIELD   hThis,
                                         int32_t     nZSlice,
                                         float*      pfBuffer)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oScalarFields.roGet(hThis)->GetSlice(nZSlice, pfBuffer);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void ScalarField_TraverseActive( PKINSTANCE hLib,
                                             PKSCALARFIELD hThis,
                                             PKFnTraverseActiveS pfnCallback)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oScalarFields.roGet(hThis)
         ->TraverseActive(pfnCallback);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKVECTORFIELD VectorField_hCreate(PKINSTANCE hLib)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVectorFields.hAdd(std::make_shared<VectorField>(roLib->fVoxelSizeMM()));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVECTORFIELD VectorField_hCreateCopy(   PKINSTANCE hLib,
                                                     PKVECTORFIELD hSource)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     VectorField::Ptr roSource = roLib->m_oVectorFields.roGet(hSource);
     VectorField::Ptr roNew = std::make_shared<VectorField>(*roSource);
     return roLib->m_oVectorFields.hAdd(roNew);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool VectorField_bIsValid(   PKINSTANCE hLib,
                                         PKVECTORFIELD hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVectorFields.bIsValid(hThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void VectorField_Destroy(    PKINSTANCE hLib,
                                         PKVECTORFIELD hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -1129,11 +1514,14 @@ PICOGK_API void VectorField_Destroy(    PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oVectorFields.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKVECTORFIELD VectorField_hCreateFromVoxels( PKINSTANCE hLib,
                                                         PKVOXELS hVoxels)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr         roVoxels    = roLib->m_oVoxels.roGet(hVoxels);
@@ -1141,6 +1529,8 @@ PICOGK_API PKVECTORFIELD VectorField_hCreateFromVoxels( PKINSTANCE hLib,
     
     roField->AddGradientFieldFrom(roVoxels);
     return roLib->m_oVectorFields.hAdd(roField);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKVECTORFIELD VectorField_hBuildFromVoxels(  PKINSTANCE hLib,
@@ -1148,6 +1538,7 @@ PICOGK_API PKVECTORFIELD VectorField_hBuildFromVoxels(  PKINSTANCE hLib,
                                                         const PKVector3* pvecValue,
                                                         float fSdThreshold)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     Voxels::Ptr         roVoxels    = roLib->m_oVoxels.roGet(hVoxels);
@@ -1155,13 +1546,18 @@ PICOGK_API PKVECTORFIELD VectorField_hBuildFromVoxels(  PKINSTANCE hLib,
     
     roField->BuildFieldFrom(roVoxels, *pvecValue, fSdThreshold);
     return roLib->m_oVectorFields.hAdd(roField);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int64_t VectorField_nMemUsage(   PKINSTANCE hLib,
                                             PKVECTORFIELD hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVectorFields.roGet(hThis)->nMemUsage();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void VectorField_SetValue(   PKINSTANCE hLib,
@@ -1169,11 +1565,14 @@ PICOGK_API void VectorField_SetValue(   PKINSTANCE hLib,
                                         const PKVector3*    pvecPosition,
                                         const PKVector3*    pvecValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     roLib->m_oVectorFields.roGet(hThis)
         ->SetValue( *pvecPosition,
                     *pvecValue);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool VectorField_bGetValue(  PKINSTANCE          hLib,
@@ -1181,59 +1580,78 @@ PICOGK_API bool VectorField_bGetValue(  PKINSTANCE          hLib,
                                         const PKVector3*    pvecPosition,
                                         PKVector3*          pvecValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     return roLib->m_oVectorFields.roGet(hThis)
         ->bGetValue(    *pvecPosition,
                         pvecValue);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void VectorField_RemoveValue(    PKINSTANCE          hLib,
                                             PKVECTORFIELD       hThis,
                                             const PKVector3*    pvecPosition)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     roLib->m_oVectorFields.roGet(hThis)
         ->RemoveValue(*pvecPosition);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void VectorField_TraverseActive( PKINSTANCE hLib,
                                             PKVECTORFIELD hThis,
                                             PKFnTraverseActiveV pfnCallback)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVectorFields.roGet(hThis)
         ->TraverseActive(pfnCallback);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKMETADATA Metadata_hFromVoxels( PKINSTANCE hLib,
                                             PKVOXELS hField)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     auto roField = roLib->m_oVoxels.roGet(hField);
     return roLib->m_oVdbMetas.hAdd(std::make_shared<VdbMeta>(roField->roVdbGrid()));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKMETADATA Metadata_hFromScalarField(    PKINSTANCE hLib,
                                                     PKSCALARFIELD hField)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     auto roField = roLib->m_oScalarFields.roGet(hField);
     return roLib->m_oVdbMetas.hAdd(std::make_shared<VdbMeta>(roField->roVdbGrid()));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API PKMETADATA Metadata_hFromVectorField(    PKINSTANCE hLib,
                                                     PKVECTORFIELD hField)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     auto roField = roLib->m_oVectorFields.roGet(hField);
     return roLib->m_oVdbMetas.hAdd(std::make_shared<VdbMeta>(roField->roVdbGrid()));
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Metadata_Destroy(   PKINSTANCE hLib,
                                     PKMETADATA hThis)
 {
+    PICOGK_GUARD_TRY
     // Library may have been cleaned up already, whereas the object
     // could still be alive due to delayed gargabe collector
     if (Library::oLib().bIsValid(hLib))
@@ -1241,22 +1659,30 @@ PICOGK_API void Metadata_Destroy(   PKINSTANCE hLib,
         Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
         roLib->m_oVdbMetas.bDestroy(hThis);
     }
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API int32_t Metadata_nCount( PKINSTANCE hLib,
                                     PKMETADATA hThis)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbMetas.roGet(hThis)->nCount();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t Metadata_nNameLengthAt(  PKINSTANCE hLib,
                                             PKMETADATA  hThis,
                                             int32_t     nIndex)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     std::string strName = roLib->m_oVdbMetas.roGet(hThis)->strNameAt(nIndex);
     return (int32_t) strName.length();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool Metadata_bGetNameAt(    PKINSTANCE hLib,
@@ -1265,6 +1691,7 @@ PICOGK_API bool Metadata_bGetNameAt(    PKINSTANCE hLib,
                                         char*       psz,
                                         int32_t     nMaxStringLen)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
     if (nIndex >= roLib->m_oVdbMetas.roGet(hThis)->nCount())
@@ -1280,20 +1707,26 @@ PICOGK_API bool Metadata_bGetNameAt(    PKINSTANCE hLib,
     psz[nMaxStringLen-1] = 0;
     
     return true;
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API int32_t Metadata_nTypeAt(    PKINSTANCE hLib,
                                         PKMETADATA  hThis,
                                         const char* psz)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return (int32_t) roLib->m_oVdbMetas.roGet(hThis)->eTypeAt(psz);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API int32_t Metadata_nStringLengthAt(    PKINSTANCE hLib,
                                                 PKMETADATA          hThis,
                                                 const char*         psz)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     
      std::string str;
@@ -1301,6 +1734,8 @@ PICOGK_API int32_t Metadata_nStringLengthAt(    PKINSTANCE hLib,
         return 0;
     
     return (int32_t) str.length();
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool Metadata_bGetStringAt(  PKINSTANCE hLib,
@@ -1309,6 +1744,7 @@ PICOGK_API bool Metadata_bGetStringAt(  PKINSTANCE hLib,
                                         char*           pszValue,
                                         int32_t         nMaxStringLen)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
      std::string s;
   
@@ -1323,6 +1759,8 @@ PICOGK_API bool Metadata_bGetStringAt(  PKINSTANCE hLib,
     pszValue[nMaxStringLen-1] = 0;
     
     return true;
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API bool Metadata_bGetFloatAt(   PKINSTANCE hLib,
@@ -1330,8 +1768,11 @@ PICOGK_API bool Metadata_bGetFloatAt(   PKINSTANCE hLib,
                                         const char*     psz,
                                         float*          pfValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbMetas.roGet(hThis)->bGetValueAt(psz, pfValue);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API bool Metadata_bGetVectorAt(  PKINSTANCE hLib,
@@ -1339,8 +1780,11 @@ PICOGK_API bool Metadata_bGetVectorAt(  PKINSTANCE hLib,
                                         const char*     psz,
                                         PKVector3*      pvecValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbMetas.roGet(hThis)->bGetValueAt(psz, pvecValue);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Metadata_SetStringValue(    PKINSTANCE hLib,
@@ -1348,8 +1792,11 @@ PICOGK_API void Metadata_SetStringValue(    PKINSTANCE hLib,
                                             const char*    pszFieldName,
                                             const char*    pszValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbMetas.roGet(hThis)->SetValue(pszFieldName, pszValue);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Metadata_SetFloatValue( PKINSTANCE hLib,
@@ -1357,8 +1804,11 @@ PICOGK_API void Metadata_SetFloatValue( PKINSTANCE hLib,
                                         const char*     pszFieldName,
                                         float           fValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     return roLib->m_oVdbMetas.roGet(hThis)->SetValue(pszFieldName, fValue);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Metadata_SetVectorValue(    PKINSTANCE hLib,
@@ -1366,16 +1816,22 @@ PICOGK_API void Metadata_SetVectorValue(    PKINSTANCE hLib,
                                             const char*         pszFieldName,
                                             const PKVector3*    pvecValue)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVdbMetas.roGet(hThis)->SetValue(pszFieldName, *pvecValue);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void MetaData_RemoveValue(   PKINSTANCE hLib,
                                         PKMETADATA  hThis,
                                         const char* pszFieldName)
 {
+    PICOGK_GUARD_TRY
     Library::Instance::Ptr roLib = Library::oLib().roGetInstance(hLib);
     roLib->m_oVdbMetas.roGet(hThis)->RemoveAt(pszFieldName);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKVIEWER Viewer_hCreate( const char*             pszWindowTitle,
@@ -1388,6 +1844,7 @@ PICOGK_API PKVIEWER Viewer_hCreate( const char*             pszWindowTitle,
                                     PKPFScrollWheel         pfnScrollWheelCallback,
                                     PKPFWindowSize          pfnWindowSize)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_hCreate);
     
     return (PKVIEWER) ViewerManager::oMgr().poCreate(
@@ -1400,72 +1857,95 @@ PICOGK_API PKVIEWER Viewer_hCreate( const char*             pszWindowTitle,
                 pfnMouseButtonCallback,
                 pfnScrollWheelCallback,
                 pfnWindowSize);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API bool Viewer_bIsValid(PKVIEWER hThis)
 {
+    PICOGK_GUARD_TRY
     //PKTRACE(Viewer_bIsValid);
     
     Viewer* poThis = (Viewer*) hThis;
     return ViewerManager::oMgr().bIsValid(poThis);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Viewer_Destroy(PKVIEWER hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_Destroy);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     PicoGK::ViewerManager::oMgr().Destroy(poThis);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_RequestUpdate(PKVIEWER hThis)
 {
+    PICOGK_GUARD_TRY
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RequestUpdate();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool Viewer_bPoll(PKVIEWER hThis)
 {
+    PICOGK_GUARD_TRY
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     return poThis->bPoll();
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API  void Viewer_RequestScreenShot(  PKVIEWER        hThis,
                                             const char*     pszScreenShotPath)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_RequestScreenShot);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RequestScreenShot(pszScreenShotPath);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_EnableExperimental(  PKVIEWER    hThis,
                                             bool        bEnable)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_EnableExperimental);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->EnableExperimental(bEnable);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_RequestClose(PKVIEWER hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_RequestClose);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RequestClose();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API bool Viewer_bLoadLightSetup( PKVIEWER        hThis,
@@ -1474,6 +1954,7 @@ PICOGK_API bool Viewer_bLoadLightSetup( PKVIEWER        hThis,
                                         const char*     pSpecTextureDDS,
                                         int32_t         nSpecTextureSize)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_bLoadLightSetup);
     
     Viewer* poThis = (Viewer*) hThis;
@@ -1483,6 +1964,8 @@ PICOGK_API bool Viewer_bLoadLightSetup( PKVIEWER        hThis,
                                     nDiffTextureSize,
                                     pSpecTextureDDS,
                                     nSpecTextureSize);
+
+    PICOGK_GUARD_CATCH(false)
 }
 
 PICOGK_API void Viewer_AddMesh( PKINSTANCE hLib,
@@ -1490,24 +1973,30 @@ PICOGK_API void Viewer_AddMesh( PKINSTANCE hLib,
                                 int32_t     nGroupID,
                                 PKMESH      hMesh)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_AddMesh);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->AddMesh(nGroupID, hLib, hMesh);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_RemoveMesh(  PKINSTANCE hLib,
                                     PKVIEWER    hThis,
                                     PKMESH      hMesh)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_RemoveMesh);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RemoveMesh(hLib, hMesh);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API  void Viewer_SetMeshMatrix(  PKINSTANCE          hLib,
@@ -1515,12 +2004,15 @@ PICOGK_API  void Viewer_SetMeshMatrix(  PKINSTANCE          hLib,
                                         PKMESH              hMesh,
                                         const PKMatrix4x4*  pmat)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SetMeshMatrix);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetMeshMatrix(hLib, hMesh, *pmat);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_AddVoxels(   PKINSTANCE hLib,
@@ -1528,24 +2020,30 @@ PICOGK_API void Viewer_AddVoxels(   PKINSTANCE hLib,
                                     int32_t     nGroupID,
                                     PKVOXELS    hVoxels)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_AddVoxels);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->AddVoxels(nGroupID, hLib, hVoxels);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_RemoveVoxels(    PKINSTANCE  hLib,
                                         PKVIEWER    hThis,
                                         PKVOXELS    hVoxels)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_RemoveVoxels);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RemoveVoxels(hLib, hVoxels);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API  void Viewer_SetVoxelsMatrix(    PKINSTANCE          hLib,
@@ -1553,12 +2051,15 @@ PICOGK_API  void Viewer_SetVoxelsMatrix(    PKINSTANCE          hLib,
                                             PKVOXELS            hVoxels,
                                             const PKMatrix4x4*  pmat)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SetVoxelsMatrix);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetVoxelsMatrix(hLib, hVoxels, *pmat);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 
@@ -1567,24 +2068,30 @@ PICOGK_API void Viewer_AddPolyLine( PKINSTANCE hLib,
                                     int32_t     nGroupID,
                                     PKPOLYLINE  hPolyLine)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_AddPolyLine);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->AddPolyLine(nGroupID, hLib, hPolyLine);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_RemovePolyLine(  PKINSTANCE hLib,
                                         PKVIEWER    hThis,
                                         PKPOLYLINE  hPolyLine)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_RemovePolyLine);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RemovePolyLine(hLib, hPolyLine);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API  void Viewer_SetPolyLineMatrix(  PKINSTANCE          hLib,
@@ -1592,34 +2099,43 @@ PICOGK_API  void Viewer_SetPolyLineMatrix(  PKINSTANCE          hLib,
                                             PKPOLYLINE          hPolyLine,
                                             const PKMatrix4x4*  pmat)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SetPolyLineMatrix);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetPolyLineMatrix(hLib, hPolyLine, *pmat);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_RemoveAllObjects(PKVIEWER hThis)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_RemoveAllObjects);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RemoveAllObjects();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_SetGroupVisible( PKVIEWER    hThis,
                                         int32_t     nGroupID,
                                         bool        bVisible)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SetGroupVisible);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetGroupVisible(nGroupID, bVisible);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API  void Viewer_SetGroupMaterial(   PKVIEWER            hThis,
@@ -1628,24 +2144,30 @@ PICOGK_API  void Viewer_SetGroupMaterial(   PKVIEWER            hThis,
                                             float               fMetallic,
                                             float               fRoughness)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SetGroupMaterial);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetGroupMaterial(nGroupID, *pclr, fMetallic, fRoughness);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_SetGroupMatrix(  PKVIEWER            hThis,
                                         int32_t             nGroupID,
                                         const PKMatrix4x4*  pmat)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SetGroupMatrix);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetGroupMatrix(nGroupID, *pmat);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_EnableGroupWarnOverhang( PKVIEWER    hThis,
@@ -1653,34 +2175,43 @@ PICOGK_API void Viewer_EnableGroupWarnOverhang( PKVIEWER    hThis,
                                                 float       fWarning,
                                                 float       fError)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_EnableGroupWarnOverhang);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->EnableGroupWarnOverhang(nGroupID, fWarning, fError);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_DisableGroupWarnOverhang(    PKVIEWER    hThis,
                                                     int32_t     nGroupID)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_DisableGroupWarnOverhang);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->DisableGroupWarnOverhang(nGroupID);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_GetBoundingBox(  PKVIEWER hThis,
                                         PKBBox3* poBox)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_GetBoundingBox);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     *poBox = poThis->oBBox();
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKGPUTEX Viewer_GpuTex_hCreate(      PKVIEWER    hThis,
@@ -1688,35 +2219,44 @@ PICOGK_API PKGPUTEX Viewer_GpuTex_hCreate(      PKVIEWER    hThis,
                                                 int         nHeight,
                                                 const char* pRgba8)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_hCreateGpuTex);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     return poThis->hGpuTexCreate(nWidth, nHeight, pRgba8);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Viewer_GpuTex_Refresh(          PKVIEWER    hThis,
                                                 PKGPUTEX    hTex,
                                                 const char* pRgba8)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_GpuTex_Refresh);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     return poThis->GpuTexRefresh(hTex, pRgba8);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_GpuTex_MarkForCleanup(   PKVIEWER hThis,
                                                 PKGPUTEX hTex)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_GpuTex_MarkForCleanup);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->GpuTexMarkForCleanup(hTex);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKQUAD Viewer_Quad_hCreate(  PKVIEWER            hThis,
@@ -1728,6 +2268,7 @@ PICOGK_API PKQUAD Viewer_Quad_hCreate(  PKVIEWER            hThis,
                                         bool                bFlipY,
                                         bool                bDoubleSided)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_Quad_hCreate);
     
     Viewer* poThis = (Viewer*) hThis;
@@ -1740,29 +2281,37 @@ PICOGK_API PKQUAD Viewer_Quad_hCreate(  PKVIEWER            hThis,
                                 bFlipX,
                                 bFlipY,
                                 bDoubleSided);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Viewer_Quad_Destroy(    PKVIEWER    hThis,
                                         PKQUAD      hQuad)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_Quad_Destroy);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->RemoveQuad(hQuad);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API void Viewer_Quad_SetMatrix(  PKVIEWER            hThis,
                                         PKQUAD              hQuad,
                                         const PKMatrix4x4*  pmat)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_Quad_SetMatrix);
     
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->SetQuadMatrix(hQuad, *pmat);
+
+    PICOGK_GUARD_CATCH_VOID
 }
 
 PICOGK_API PKGUI Viewer_SideBar_hCreate(    PKVIEWER        hThis,
@@ -1773,6 +2322,7 @@ PICOGK_API PKGUI Viewer_SideBar_hCreate(    PKVIEWER        hThis,
                                             PKColorFloat    clrBackground,
                                             PKColorFloat    clrBackgroundHv)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SideBar_hCreate);
     
     Viewer* poThis = (Viewer*) hThis;
@@ -1784,15 +2334,20 @@ PICOGK_API PKGUI Viewer_SideBar_hCreate(    PKVIEWER        hThis,
                                     nDef,
                                     clrBackground,
                                     clrBackgroundHv);
+
+    PICOGK_GUARD_CATCH(0)
 }
 
 PICOGK_API void Viewer_SideBar_Destroy( PKVIEWER hThis,
                                         PKGUI hSideBar)
 {
+    PICOGK_GUARD_TRY
     PKTRACE(Viewer_SideBar_Destroy);
 
     Viewer* poThis = (Viewer*) hThis;
     assert(ViewerManager::oMgr().bIsValid(poThis));
     
     poThis->DestroySideBar(hSideBar);
+
+    PICOGK_GUARD_CATCH_VOID
 }


### PR DESCRIPTION
Addresses #27 — harden the C ABI so a thrown C++/OpenVDB exception becomes a catchable error in the caller instead of a process abort.

## Problem
Every `extern "C"` `PICOGK_API` function can let a C++ exception propagate across the FFI boundary. That's undefined behaviour and in practice calls `std::terminate`, killing the host process. A C# caller can `try/catch`; a C-ABI binding (Python `ctypes`, Rust FFI, …) cannot — there's no C++ frame to unwind into. Examples that abort today: a CSG/second implicit intersect on a non-level-set grid (OpenVDB `ValueError`), an out-of-range VDB field index (`std::vector::at` → `std::out_of_range`).

## Change (`Source/PicoGKLibrary.cpp` only)
- Add a small infra block: `PicoGK_SetError` / `PicoGK_nGetLastError` and an exported `g_pkLastErrorFlag`, plus `PICOGK_GUARD_TRY` / `PICOGK_GUARD_CATCH(sentinel)` macros.
- Wrap the body of each of the **173** `PICOGK_API` functions in `try/catch`, returning a type-appropriate sentinel (`void`→`;`, `bool`→`false`, handle/int→`0`, `float`→`NaN`). A binding clears the flag on entry, reads it after each call, and raises.

The diff is large but **entirely mechanical** — the reviewable core is the ~40-line infra block at the top and the uniform two-line wrap repeated per function. It's produced by an idempotent script, so it can be re-generated for future runtime versions rather than hand-maintained.

## Properties
- **No behavioural change** for calls that don't throw (flag cleared on entry, set only in a `catch`).
- The C# wrapper is unaffected (it never reads the flag).
- Does **not** cover hard faults (`SIGSEGV` from e.g. a NaN reaching native math) or hangs — those are best guarded at the binding boundary; this converts the large class of *thrown* exceptions.

## Verification
This exact transform is what [PicoPie](https://github.com/Borderliner/PicoPie) applies to the pinned runtime at build time; it **compiles and ships on Linux, macOS, and Windows** in PicoPie's wheel CI, and a subprocess fuzz campaign of degenerate inputs (NaN/inf, empty grids, repeated CSG) runs with zero process aborts.

## Open to adjustment
Happy to tailor the approach to your preferences — e.g. making the last-error string `thread_local` for multi-threaded API use (currently a single file-scope global), the symbol names, or limiting the scope to the throw-prone subset rather than all functions.

---
*Reported & implemented via [PicoPie](https://github.com/Borderliner/PicoPie), a Pythonic binding of PicoGK.*
